### PR TITLE
Aligerar las imagenes docker

### DIFF
--- a/gba/Dockerfile
+++ b/gba/Dockerfile
@@ -1,17 +1,18 @@
 FROM ubuntu:latest
-RUN apt update
+
 ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=Europe/Madrid
-RUN apt install -yq wget curl libarchive13 xz-utils make
-RUN apt install -yq gpg pkg-config
-RUN wget https://github.com/devkitPro/pacman/releases/download/v1.0.2/devkitpro-pacman.amd64.deb
-RUN dpkg -i devkitpro-pacman.amd64.deb
-RUN ln -s /proc/self/mounts /etc/mtab
-RUN all | dkp-pacman --noconfirm -S gba-dev
+RUN apt update && \
+  apt install -yq wget curl libarchive13 xz-utils make gpg pkg-config && \
+  wget https://github.com/devkitPro/pacman/releases/download/v1.0.2/devkitpro-pacman.amd64.deb && \
+  dpkg -i devkitpro-pacman.amd64.deb && \
+  ln -s /proc/self/mounts /etc/mtab && \
+  all | dkp-pacman --noconfirm -S gba-dev \
+  mkdir -p /src/gba
 ENV DEVKITARM=/opt/devkitpro/devkitARM
 ENV DEVKITPRO=/opt/devkitpro
 ENV DEVKITPPC=/opt/devkitpro/devkitPPC
-RUN mkdir -p /src/gba
+
 WORKDIR /src/gba
 VOLUME ["/src/gba"]
 CMD ["make"]

--- a/nds/Dockerfile
+++ b/nds/Dockerfile
@@ -1,17 +1,19 @@
 FROM ubuntu:latest
-RUN apt update
+
 ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=Europe/Madrid
-RUN apt install -yq wget curl libarchive13 xz-utils make
-RUN apt install -yq gpg pkg-config
-RUN wget https://github.com/devkitPro/pacman/releases/download/v1.0.2/devkitpro-pacman.amd64.deb
-RUN dpkg -i devkitpro-pacman.amd64.deb
-RUN ln -s /proc/self/mounts /etc/mtab
-RUN all | dkp-pacman --noconfirm -S nds-dev
+
+RUN apt update && \
+  apt install -yq wget curl libarchive13 xz-utils make gpg pkg-config && \
+  wget https://github.com/devkitPro/pacman/releases/download/v1.0.2/devkitpro-pacman.amd64.deb && \
+  dpkg -i devkitpro-pacman.amd64.deb && \
+  ln -s /proc/self/mounts /etc/mtab && \
+  all | dkp-pacman --noconfirm -S nds-dev && \
+  mkdir -p /src/nds
+
 ENV DEVKITARM=/opt/devkitpro/devkitARM
 ENV DEVKITPRO=/opt/devkitpro
 ENV DEVKITPPC=/opt/devkitpro/devkitPPC
-RUN mkdir -p /src/nds
 WORKDIR /src/nds
 VOLUME ["/src/nds"]
 CMD ["make"]

--- a/sdl/Dockerfile
+++ b/sdl/Dockerfile
@@ -1,21 +1,22 @@
 FROM ubuntu:latest
-RUN apt update
-RUN apt install -y build-essential wget
+
 ENV DEBIAN_FRONTEND=nointeractive
 ENV TZ=Europe/Madrid
-RUN apt install -yq libsdl2-dev libsdl2-ttf-dev libsdl2-image-dev libsdl2-mixer-dev
-RUN apt install -yq mingw-w64
-RUN apt install -yq zip
-RUN mkdir -p ~/sdl_win
-RUN wget https://www.libsdl.org/release/SDL2-devel-2.0.18-mingw.tar.gz -P ~/sdl_win
-RUN tar xf ~/sdl_win/SDL2-devel-2.0.18-mingw.tar.gz -C ~/sdl_win
-RUN wget https://www.libsdl.org/projects/SDL_image/release/SDL2_image-devel-2.0.5-mingw.tar.gz -P ~/sdl_win
-RUN tar xf ~/sdl_win/SDL2_image-devel-2.0.5-mingw.tar.gz -C ~/sdl_win
-RUN wget https://www.libsdl.org/projects/SDL_ttf/release/SDL2_ttf-devel-2.0.15-mingw.tar.gz -P ~/sdl_win
-RUN tar xf ~/sdl_win/SDL2_ttf-devel-2.0.15-mingw.tar.gz -C ~/sdl_win
-RUN wget https://www.libsdl.org/projects/SDL_mixer/release/SDL2_mixer-devel-2.0.4-mingw.tar.gz -P ~/sdl_win
-RUN tar xvf ~/sdl_win/SDL2_mixer-devel-2.0.4-mingw.tar.gz -C ~/sdl_win
-RUN mkdir -p /src/sdl2
+
+RUN apt update
+  apt install -y build-essential wget && \
+  apt install -yq libsdl2-dev libsdl2-ttf-dev libsdl2-image-dev libsdl2-mixer-dev mingw-w64 zip && \
+  mkdir -p ~/sdl_win && \
+  wget https://www.libsdl.org/release/SDL2-devel-2.0.18-mingw.tar.gz -P ~/sdl_win && \
+  tar xf ~/sdl_win/SDL2-devel-2.0.18-mingw.tar.gz -C ~/sdl_win && \
+  wget https://www.libsdl.org/projects/SDL_image/release/SDL2_image-devel-2.0.5-mingw.tar.gz -P ~/sdl_win && \
+  tar xf ~/sdl_win/SDL2_image-devel-2.0.5-mingw.tar.gz -C ~/sdl_win && \
+  wget https://www.libsdl.org/projects/SDL_ttf/release/SDL2_ttf-devel-2.0.15-mingw.tar.gz -P ~/sdl_win && \
+  tar xf ~/sdl_win/SDL2_ttf-devel-2.0.15-mingw.tar.gz -C ~/sdl_win && \
+  wget https://www.libsdl.org/projects/SDL_mixer/release/SDL2_mixer-devel-2.0.4-mingw.tar.gz -P ~/sdl_win && \
+  tar xvf ~/sdl_win/SDL2_mixer-devel-2.0.4-mingw.tar.gz -C ~/sdl_win && \
+  mkdir -p /src/sdl2
+
 VOLUME ["/src/sdl2"]
 WORKDIR /src/sdl2
 CMD ["make", "game.zip"]


### PR DESCRIPTION
Es una buena práctica que en la creación de imagenes docker, usar cuanto menos capas sean posibles. Cada comando del Dockerfile va a ser una capa, asi que he comprimido todos los RUN en uno solo.